### PR TITLE
Fix props type check.

### DIFF
--- a/lib/Stack.js
+++ b/lib/Stack.js
@@ -17,7 +17,7 @@ class Stack extends Component {
     renderRightSegment: func,
     animationType: string,
     gestureEnabled: bool,
-    stackViewStyle: object
+    stackViewStyle: View.propTypes.style
   };
 
   static defaultProps = {

--- a/lib/StackTransitioner.js
+++ b/lib/StackTransitioner.js
@@ -24,7 +24,7 @@ export default class StackTransitioner extends Component {
     height: number.isRequired,
     animationType: string.isRequired,
     gestureEnabled: bool,
-    stackViewStyle: object
+    stackViewStyle: View.propTypes.style
   };
 
   state = {


### PR DESCRIPTION
Fix type checking introduced in #8 .

This avoid Warning when using `StyleSheet.create()` which is returning a number as reference.