### PR TITLE
Allow transitions for the same Route entry to be skipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,29 @@ when it pops off of the stack. Here's how it looks:
 
 ![Per-Route Animation Type Example](https://raw.githubusercontent.com/traviskn/react-router-native-stack/master/media/per-route-animation-type-ios.gif)
 
+## Nested routes
+
+Where one of the Routes in the Stack have nested Routes the default behaviour is to
+animate between pages as if you were changing to completely different route.
+
+Sometimes this behaviour is not what you want (for example when creating a page
+to show items, where items can be deep linked to, but only form part of the page).
+In this case you can add a key to the Route, and "self"-transitions are then
+ignored.
+
+```javascript
+  <Stack>
+    <Route exact path="/" component={Home} />
+    { /* animates moving to /items, but not when changing itemId */ }
+    <Route path="/items/:itemId?" component={Items} key="items"/>
+  </Stack>
+  
+  const Items = ({match}) =>
+    <View>
+       <Text>Items finder</Text>
+       <Text>Looking at item {match.params.itemId}</Text>
+    </View>
+```
 
 ## Known Limitations
 

--- a/lib/StackTransitioner.js
+++ b/lib/StackTransitioner.js
@@ -156,7 +156,8 @@ export default class StackTransitioner extends Component {
     if (
       this.isPanning ||
       nextProps.animationType === NONE ||
-      (history.action === POP && history.index < this.startingIndex)
+      (history.action === POP && history.index < this.startingIndex) ||
+      (previousChildren && children.key === previousChildren.key)
     ) {
       return;
     }
@@ -250,29 +251,29 @@ export default class StackTransitioner extends Component {
     let routes = [];
     if (transition === PUSH) {
       routes.push(
-        <Animated.View key={previousLocation.key} style={this.getRouteStyle(0)}>
+        <Animated.View key={previousChildren.key} style={this.getRouteStyle(0)}>
           {previousChildren}
         </Animated.View>
       );
       routes.push(
-        <Animated.View key={location.key} style={this.getRouteStyle(1)}>
+        <Animated.View key={children.key} style={this.getRouteStyle(1)}>
           {children}
         </Animated.View>
       );
     } else if (transition === POP || this.isPanning) {
       routes.push(
-        <Animated.View key={location.key} style={this.getRouteStyle(0)}>
+        <Animated.View key={children.key} style={this.getRouteStyle(0)}>
           {children}
         </Animated.View>
       );
       routes.push(
-        <Animated.View key={previousLocation.key} style={this.getRouteStyle(1)}>
+        <Animated.View key={previousChildren.key} style={this.getRouteStyle(1)}>
           {previousChildren}
         </Animated.View>
       );
     } else {
       routes.push(
-        <Animated.View key={location.key} style={[styles.stackView, stackViewStyle]}>
+        <Animated.View key={children.key} style={[styles.stackView, stackViewStyle]}>
           {children}
         </Animated.View>
       );

--- a/lib/findFirstMatch.js
+++ b/lib/findFirstMatch.js
@@ -17,5 +17,5 @@ export default function findFirstMatch(children, location) {
     }
   });
 
-  return match ? React.cloneElement(child, { location, computedMatch: match }) : null;
+  return match ? React.cloneElement(child, { location, computedMatch: match, key: child.key || location.key }) : null;
 }


### PR DESCRIPTION
If I have a Stack and a number of Routes under it, everything is fine.
But when some of those routes have sub-routes, we may not want animations to occur. For example, where we're handling routes as optional parts of an existing page the transition will trash any existing component state; we can solve this with redux or similar, but that adds complication where it often isn't otherwise needed.

Currently whether to do a push transition animation is mainly determined by whether the location key has changed.
This commit changes that, so that if a key has been specified on the Route inside the stack, that key is used instead.

The effect is that any sub routes of routes with keys do not animate transition.

For example:

    <Stack>
      <Route path="/" exact component={Home}/>
      <Route path="/login" component={Login}/>
      <Route path="/account" component={Account} key="account"/>
    </Stack>

    /login -> /login/complete will animate
    /login -> /account will animate
    /account -> /account/:transactionId will _not_ animate

Existing behaviour is not changed unless keys are present.