### PR TITLE
Support animationType="none" on Stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-debug.log
 android/build
 ios/**/*xcuserdata*
 ios/**/*xcshareddata*
+yarn.lock

--- a/lib/StackTransitioner.js
+++ b/lib/StackTransitioner.js
@@ -162,7 +162,7 @@ export default class StackTransitioner extends Component {
 
     if (
       this.isPanning ||
-      nextProps.animationType === NONE ||
+      (routeAnimationType === NONE || (nextProps.animationType === NONE && !routeAnimationType)) ||
       (action === POP && history.index < this.startingIndex) ||
       (children && previousChildren && children.key === previousChildren.key)
     ) {


### PR DESCRIPTION
Scenario: for majority of my routes I *don't* want a transition animation, so I'd like my `<Stack>` to have `"none"` animation, and then manually "turn on" the specific routes that I *do* want an animation for:

```js
<Stack animationType="none">
  <Route path="/foo">
  <Route path="/bar">
  <Route path="/baz">
  <Route path="/hello">
  <Route path="/animated" animationType="slide-horizontal">
</Stack>
```

... this doesn't work at the moment because of a check to see if the Stack's `nextProps` has an `animationType` of `"none"` (which in the scenario above, will be always), so no animation is ever performed. This PR addresses that by giving the route animation type precedence.