### PR TITLE
Prevent gestures while transition is active

### DIFF
--- a/lib/StackTransitioner.js
+++ b/lib/StackTransitioner.js
@@ -50,6 +50,7 @@ export default class StackTransitioner extends Component {
   panResponder = PanResponder.create({
     onMoveShouldSetPanResponder: (event, gesture) => {
       return (
+        !this.state.transition &&
         this.isHorizontal(this.state.routeAnimationType || this.props.animationType) &&
         this.props.gestureEnabled &&
         this.props.history.index > this.startingIndex &&
@@ -139,7 +140,7 @@ export default class StackTransitioner extends Component {
     const { history } = nextProps;
     const { location } = this.props;
 
-    if (nextProps.location.key === location.key) {
+    if (nextProps.location.key === location.key || !!this.state.transition) {
       return;
     }
 


### PR DESCRIPTION
The default behaviour on iOS is to block "back" gestures while transitions are still occurring (not entirely sure what the default on Android is, but at any rate, the described bug below is present on Android too). 

I think this package should also block gestures during transitions because otherwise you get weird bugs when you try to swipe-right-to-go-back while the new route is still transitioning in. Here are some gifs that demonstrate the bug:

<img src="https://user-images.githubusercontent.com/5670279/44583494-818cea00-a79d-11e8-8d26-8cd95bf5b7d8.gif" width="300" />

<img src="https://user-images.githubusercontent.com/5670279/44583502-8487da80-a79d-11e8-9023-e79cc7023e4d.gif" width="300" />

<img src="https://user-images.githubusercontent.com/5670279/44583504-86ea3480-a79d-11e8-9185-eb5a62fb278f.gif" width="300" />

The fix is simple and involves blocking the following while the transition is active:
  * PanResponder from responding to the touch
  * the component from updating its state .