### PR TITLE
isAnimating prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,33 @@ ignored.
     </View>
 ```
 
+## `isAnimating` handler
+
+Sometimes you'll want your app to respond a certain way while a route transition animation
+is occurring. For example you may want to prevent custom `<Link>`'s  and `<Button>`'s from
+performing their usual behaviour (manipulating the `history`) should a route transition be
+occurring at that very moment. This helps prevent bugs around users pressing the "back" button
+before the current route has finished animating in. To this end, you can pass the `Stack` an
+`isAnimating` function which will be called with a boolean value based on the current
+state of the route transition.
+
+```javascript
+<Stack
+  animationType='slide-horizontal'
+  isAnimating={(value) => {
+    reduxStore.dispatch(myActionHere(value));
+  }}
+>
+  <Route exact= path='/' component={Home} />
+  <Route path='/page/:name' component={Page} />
+</Stack>
+```
+
+One way of handling the above scenario would be to use a redux dispatcher as my `isAnimating`
+handler and subsequently have all my `<Button>`'s and `<Link>`'s subscribe to the necessary bit
+of global state to determine whether to `disable` themselves or not. But ultimately, what your
+`isAnimating` function looks like, and how you leverage it, is up to you!
+
 ## Known Limitations
 
 Currently the stack has no built-in animations for headers or footers, but that

--- a/lib/Stack.js
+++ b/lib/Stack.js
@@ -19,12 +19,14 @@ class Stack extends Component {
     animationType: string,
     gestureEnabled: bool,
     stackViewStyle: ViewPropTypes.style,
-    replaceTransitionType: oneOf([PUSH, POP])
+    replaceTransitionType: oneOf([PUSH, POP]),
+    isAnimating: func,
   };
 
   static defaultProps = {
     animationType: Platform.OS === 'ios' ? SLIDE_HORIZONTAL : FADE_VERTICAL,
     gestureEnabled: true,
+    isAnimating: () => null,
   };
 
   state = {
@@ -49,7 +51,8 @@ class Stack extends Component {
       animationType,
       gestureEnabled,
       stackViewStyle,
-      replaceTransitionType
+      replaceTransitionType,
+      isAnimating,
     } = this.props;
 
     const { height, width } = this.state;
@@ -70,6 +73,7 @@ class Stack extends Component {
           children={children}
           stackViewStyle={stackViewStyle}
           replaceTransitionType={replaceTransitionType}
+          isAnimating={isAnimating}
         />
       </View>
     );

--- a/lib/StackTransitioner.js
+++ b/lib/StackTransitioner.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { node, object, number, bool, string, oneOf } from 'prop-types';
+import { node, object, number, bool, string, oneOf, func } from 'prop-types';
 import { Animated, PanResponder, View, ViewPropTypes } from 'react-native';
 import findFirstMatch from './findFirstMatch';
 import getTransforms from './getTransforms';
@@ -25,7 +25,8 @@ export default class StackTransitioner extends Component {
     animationType: string.isRequired,
     gestureEnabled: bool,
     stackViewStyle: ViewPropTypes.style,
-    replaceTransitionType: oneOf([PUSH, POP])
+    replaceTransitionType: oneOf([PUSH, POP]),
+    isAnimating: func
   };
 
   state = {
@@ -119,6 +120,7 @@ export default class StackTransitioner extends Component {
   };
 
   afterPan = () => {
+    this.props.isAnimating(false);
     this.isPanning = false;
 
     this.setState({
@@ -179,6 +181,8 @@ export default class StackTransitioner extends Component {
           // TODO: base slide direction on `I18nManager.isRTL`
           const dimension = this.getDimension();
 
+          this.props.isAnimating(true);
+
           this.animation = Animated.timing(this.animatedValue, {
             duration: getDuration(routeAnimationType || nextProps.animationType, action),
             toValue: action === PUSH ? -dimension : dimension,
@@ -186,6 +190,8 @@ export default class StackTransitioner extends Component {
             useNativeDriver: true,
           }).start(({ finished }) => {
             if (finished) {
+              this.props.isAnimating(false);
+
               this.setState({
                 previousLocation: {},
                 transition: null,


### PR DESCRIPTION
So I've been running into a variety of issues which at their core are about manipulations to `history` being allowed while a transition animation is still occurring. I believe that's the heart of https://github.com/Traviskn/react-router-native-stack/issues/29 as well.

I went through several different approaches, for example I initially tried to do what you suggested in #29 by wrapping the rendering of `{children}` and `{previousChildren}` in a function (eg: `{this.enhancedChildren(children)}`) that would add an additional handy prop for use by the components rendered by those routes:

```
enhancedChildren = (children) => {
    return React.Children.map(children, child => {
      return React.cloneElement(child, {
        isAnimating: !!this.state.transition
      });
    });
  }
```

... however that didn't pan out because `react-router` only passes down a specific sub-set of props to the `Route`'s `component` (same for `render`): https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/Route.js#L116 💔 (WHYYY! I mean, I'm sure they have a good reason, but also, WHYYY)

Ultimately, what I want is to be able to disable all the links and buttons in my application should an animation be occurring, so the approach of this PR was inspired by the idea that `isAnimating` would be a redux-dispatched function, and my custom `<Button>` and `<Link>` components would simply subscribe to a small bit of app state which informs them whether or not a route transition animation is occurring (and subsequently whether or not to `disable` themselves).

However this package doesn't need to know any of that^, it just allows for a user-defined `isAnimating` function prop to be passed down, and how the user leverages that is up to them.

Please let me know what you think of this approach 😄 