### PR TITLE
Unconditionally match routes without path,

### DIFF
--- a/lib/findFirstMatch.js
+++ b/lib/findFirstMatch.js
@@ -13,7 +13,7 @@ export default function findFirstMatch(children, location) {
 
     if (match == null) {
       child = element;
-      match = matchPath(location.pathname, { path, exact, strict, sensitive });
+      match = path == null ? {} : matchPath(location.pathname, { path, exact, strict, sensitive });
     }
   });
 


### PR DESCRIPTION
[React Router's no match rules](https://reacttraining.com/react-router/web/example/no-match) allow a user to default to a route without a path if not match is found in a switch. This changes react-router-native-stack to do the same.