### PR TITLE
fix bug with canceled back swipe

### DIFF
--- a/lib/StackTransitioner.js
+++ b/lib/StackTransitioner.js
@@ -101,7 +101,7 @@ export default class StackTransitioner extends Component {
       useNativeDriver: true,
     }).start(({ finished }) => {
       if (finished) {
-        this.props.history.push(this.state.previousLocation.pathname);
+        this.props.history.push(this.state.previousLocation);
         this.afterPan();
       }
     });


### PR DESCRIPTION
Fixes #45 

When canceling the swipe, we should be resetting the entire location, not just the pathname